### PR TITLE
Add door trigger to brusweb

### DIFF
--- a/hackeriet/web/brusweb/__init__.py
+++ b/hackeriet/web/brusweb/__init__.py
@@ -105,6 +105,14 @@ def admin():
     return render_template('admin.html', username=user,
                            users=members.list_users())
 
+@app.route("/brus/door/hackeriet/open", methods=['POST'])
+@requires_auth
+def open_door():
+    user=request.authorization.username
+    signature='%s (brusweb)' % user
+    mqtt('hackeriet/door/hackeriet/open', signature)
+    return 'Door triggered'
+
 @app.route("/brus/admin/add", methods=['POST'])
 @requires_admin
 def admin_add():

--- a/hackeriet/web/brusweb/templates/account.html
+++ b/hackeriet/web/brusweb/templates/account.html
@@ -6,6 +6,13 @@
 <body>
 <h1>Hei {{username}}!</h1>
 <a href="https://logg:ut@brus.hackeriet.no/brus/account">Logg ut</a>.
+
+<h2>Vil du åpne døra?</h2>
+
+<form action="/brus/door/hackeriet/open" method="post">
+  <input type="submit" name="btn_opendoor" value="Trigger Hackeriet door lock">
+</form>
+
 <h2>Din saldo er: {{balance}}</h2>
 
 <h2>Fyll på spenn</h2>


### PR DESCRIPTION
Trigger door through brusweb at https://brus.hackeriet.no/brus/account

## Possible issues
- All users that are able to log into brusweb will be able to unlock the door. This means that the hula database needs to be up to date.