### PR TITLE
fix(git submodule): updated the url for the git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/nfc-bindings"]
 	path = src/nfc-bindings
-	url = git://github.com/xantares/nfc-bindings.git
+	url = https://github.com/xantares/nfc-bindings.git


### PR DESCRIPTION
when i try to run this comand below i get a error message saying that the it cannot clone the submodule. 
`pip3 install git+https://github.com/hackeriet/pyhackeriet.git --upgrade`